### PR TITLE
Fixes #90 - Added safeguard for preHook return.

### DIFF
--- a/packages/RatPack.package/RPAntiPreHookConventionMiddleware.class/instance/preHook..st
+++ b/packages/RatPack.package/RPAntiPreHookConventionMiddleware.class/instance/preHook..st
@@ -1,0 +1,4 @@
+interaction
+preHook: anEnv
+	
+	^ self

--- a/packages/RatPack.package/RPAntiPreHookConventionMiddleware.class/methodProperties.json
+++ b/packages/RatPack.package/RPAntiPreHookConventionMiddleware.class/methodProperties.json
@@ -1,0 +1,5 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"preHook:" : "lj 7/4/2018 12:26" } }

--- a/packages/RatPack.package/RPAntiPreHookConventionMiddleware.class/properties.json
+++ b/packages/RatPack.package/RPAntiPreHookConventionMiddleware.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"category" : "RatPack-Testing",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		 ],
+	"name" : "RPAntiPreHookConventionMiddleware",
+	"pools" : [
+		 ],
+	"super" : "RPTestMiddleware",
+	"type" : "normal" }

--- a/packages/RatPack.package/RPMiddleware.class/instance/assertedPreHookResult..st
+++ b/packages/RatPack.package/RPMiddleware.class/instance/assertedPreHookResult..st
@@ -1,6 +1,6 @@
 interaction
 assertedPreHookResult: aPreHookResult
 
-	((aPreHookResult respondsTo: #ifTrue:)  or: (aPreHookResult respondsTo: #ifFalse:))
+	((aPreHookResult respondsTo: #ifTrue:) and: [ (aPreHookResult respondsTo: #ifFalse:). ])
 		ifTrue: 	[ ^ aPreHookResult ]
 		ifFalse: 	[ self error: 'preHook of: ' , self name , ' has to return true or false.' ]

--- a/packages/RatPack.package/RPMiddleware.class/instance/assertedPreHookResult..st
+++ b/packages/RatPack.package/RPMiddleware.class/instance/assertedPreHookResult..st
@@ -1,6 +1,6 @@
 interaction
 assertedPreHookResult: aPreHookResult
 
-	(aPreHookResult == true or: aPreHookResult == false)
+	((aPreHookResult respondsTo: #ifTrue:)  or: (aPreHookResult respondsTo: #ifFalse:))
 		ifTrue: 	[ ^ aPreHookResult ]
-		ifFalse: 	[ self error: 'preHook of: ' , self name , ' has to return true or false. True: process execution. False: Abort Execution.' ]
+		ifFalse: 	[ self error: 'preHook of: ' , self name , ' has to return true or false.' ]

--- a/packages/RatPack.package/RPMiddleware.class/instance/assertedPreHookResult..st
+++ b/packages/RatPack.package/RPMiddleware.class/instance/assertedPreHookResult..st
@@ -1,0 +1,6 @@
+interaction
+assertedPreHookResult: aPreHookResult
+
+	(aPreHookResult == true or: aPreHookResult == false)
+		ifTrue: 	[ ^ aPreHookResult ]
+		ifFalse: 	[ self error: 'preHook of: ' , self name , ' has to return true or false. True: process execution. False: Abort Execution.' ]

--- a/packages/RatPack.package/RPMiddleware.class/instance/handle.next..st
+++ b/packages/RatPack.package/RPMiddleware.class/instance/handle.next..st
@@ -2,9 +2,9 @@ accessing-default
 handle: anEnv next: aNext
 	
 	(self isUrlBlacklisted: anEnv request url)
-		ifTrue: [ ^ aNext value].
+		ifTrue: [ ^ aNext value ].
 		
-	(self preHook: anEnv)
+	(self assertedPreHookResult: (self preHook: anEnv))
 		ifTrue: [ aNext value.
-			 self postHook: anEnv.].
+				 self postHook: anEnv. ].
 			

--- a/packages/RatPack.package/RPMiddleware.class/instance/postHook..st
+++ b/packages/RatPack.package/RPMiddleware.class/instance/postHook..st
@@ -1,2 +1,4 @@
 interaction
 postHook: anEnv
+
+	    "Called after handler execution"

--- a/packages/RatPack.package/RPMiddleware.class/instance/preHook..st
+++ b/packages/RatPack.package/RPMiddleware.class/instance/preHook..st
@@ -1,4 +1,8 @@
 interaction
 preHook: anEnv
 
-	" return true if you want to continue handling this request. Return false if the handling should be aborted."
+	 "Called before handler execution
+	  Return true if you want to continue handling this request.
+	  Return false if the handling should be aborted. (Post Hook is not called.)"
+	
+	^ true

--- a/packages/RatPack.package/RPMiddleware.class/instance/preHook..st
+++ b/packages/RatPack.package/RPMiddleware.class/instance/preHook..st
@@ -1,7 +1,7 @@
 interaction
 preHook: anEnv
 
-	 "Called before handler execution
+	 "Called before handler execution. Return value must understand #ifTrue: or #ifFalse:
 	  Return true if you want to continue handling this request.
 	  Return false if the handling should be aborted. (Post Hook is not called.)"
 	

--- a/packages/RatPack.package/RPMiddleware.class/methodProperties.json
+++ b/packages/RatPack.package/RPMiddleware.class/methodProperties.json
@@ -2,8 +2,8 @@
 	"class" : {
 		"blacklist" : "re 6/26/2018 12:00" },
 	"instance" : {
-		"assertedPreHookResult:" : "lj 7/4/2018 13:11",
+		"assertedPreHookResult:" : "lj 7/4/2018 13:59",
 		"handle:next:" : "lj 7/4/2018 13:07",
 		"isUrlBlacklisted:" : "lj 5/25/2018 19:45",
 		"postHook:" : "lj 7/4/2018 11:56",
-		"preHook:" : "lj 7/4/2018 12:17" } }
+		"preHook:" : "lj 7/4/2018 14:09" } }

--- a/packages/RatPack.package/RPMiddleware.class/methodProperties.json
+++ b/packages/RatPack.package/RPMiddleware.class/methodProperties.json
@@ -2,7 +2,7 @@
 	"class" : {
 		"blacklist" : "re 6/26/2018 12:00" },
 	"instance" : {
-		"assertedPreHookResult:" : "lj 7/4/2018 13:59",
+		"assertedPreHookResult:" : "lj 7/4/2018 14:17",
 		"handle:next:" : "lj 7/4/2018 13:07",
 		"isUrlBlacklisted:" : "lj 5/25/2018 19:45",
 		"postHook:" : "lj 7/4/2018 11:56",

--- a/packages/RatPack.package/RPMiddleware.class/methodProperties.json
+++ b/packages/RatPack.package/RPMiddleware.class/methodProperties.json
@@ -2,7 +2,8 @@
 	"class" : {
 		"blacklist" : "re 6/26/2018 12:00" },
 	"instance" : {
-		"handle:next:" : "lj 5/25/2018 19:34",
+		"assertedPreHookResult:" : "lj 7/4/2018 13:11",
+		"handle:next:" : "lj 7/4/2018 13:07",
 		"isUrlBlacklisted:" : "lj 5/25/2018 19:45",
-		"postHook:" : "re 6/20/2018 22:08",
-		"preHook:" : "re 6/20/2018 22:09" } }
+		"postHook:" : "lj 7/4/2018 11:56",
+		"preHook:" : "lj 7/4/2018 12:17" } }

--- a/packages/RatPack.package/RPTests.class/instance/testMiddlewarePreHookConvention.st
+++ b/packages/RatPack.package/RPTests.class/instance/testMiddlewarePreHookConvention.st
@@ -1,0 +1,8 @@
+test - database - postgresql
+testMiddlewarePreHookConvention
+
+	| middleware |
+	middleware := RPAntiPreHookConventionMiddleware new.
+	self assert: (middleware assertedPreHookResult: true)  equals: true.
+	self assert: (middleware assertedPreHookResult: false) equals: false.
+	self assert: ([middleware assertedPreHookResult: (middleware preHook: nil). false] on: Error do: [true])

--- a/packages/RatPack.package/RPTests.class/instance/testMiddlewarePreHookConvention.st
+++ b/packages/RatPack.package/RPTests.class/instance/testMiddlewarePreHookConvention.st
@@ -3,6 +3,6 @@ testMiddlewarePreHookConvention
 
 	| middleware |
 	middleware := RPAntiPreHookConventionMiddleware new.
-	self assert: (middleware assertedPreHookResult: true)  equals: true.
+	self assert: (middleware assertedPreHookResult: true) equals: true.
 	self assert: (middleware assertedPreHookResult: false) equals: false.
 	self assert: ([middleware assertedPreHookResult: (middleware preHook: nil). false] on: Error do: [true])

--- a/packages/RatPack.package/RPTests.class/methodProperties.json
+++ b/packages/RatPack.package/RPTests.class/methodProperties.json
@@ -33,7 +33,7 @@
 		"testMiddlewareCallChainInterrupt" : "lj 5/25/2018 20:59",
 		"testMiddlewareCallChainOrder" : "lj 5/25/2018 19:04",
 		"testMiddlewareInstanciation" : "lj 5/22/2018 15:14",
-		"testMiddlewarePreHookConvention" : "lj 7/4/2018 13:14",
+		"testMiddlewarePreHookConvention" : "lj 7/4/2018 14:15",
 		"testMiddlewarePreHookFalse" : "lj 5/30/2018 15:02",
 		"testMiddlewarePreHookTrue" : "lj 5/30/2018 15:02",
 		"testModelNameToSnakeCase" : "jm 5/23/2018 15:52",

--- a/packages/RatPack.package/RPTests.class/methodProperties.json
+++ b/packages/RatPack.package/RPTests.class/methodProperties.json
@@ -33,6 +33,7 @@
 		"testMiddlewareCallChainInterrupt" : "lj 5/25/2018 20:59",
 		"testMiddlewareCallChainOrder" : "lj 5/25/2018 19:04",
 		"testMiddlewareInstanciation" : "lj 5/22/2018 15:14",
+		"testMiddlewarePreHookConvention" : "lj 7/4/2018 13:14",
 		"testMiddlewarePreHookFalse" : "lj 5/30/2018 15:02",
 		"testMiddlewarePreHookTrue" : "lj 5/30/2018 15:02",
 		"testModelNameToSnakeCase" : "jm 5/23/2018 15:52",


### PR DESCRIPTION
if not true or false, an error is raised, with descriptive error message.

preHook default return value now is true, so it subclasses don't need to implement it.